### PR TITLE
Fix bottom padding of chapter menu

### DIFF
--- a/app/components/ChapterList.js
+++ b/app/components/ChapterList.js
@@ -36,7 +36,7 @@ class ChapterList extends Component {
   }
 
   getRowStyle() {
-    return this.props.language.align === 'left' ? styles.ltrRow : styles.rtlRow; 
+    return this.props.language.align === 'left' ? styles.ltrRow : styles.rtlRow;
   }
 
   getItemStyle() {
@@ -56,13 +56,12 @@ ChapterList.propTypes = {
 
 const styles = StyleSheet.create({
   container: {
-    paddingVertical: 12,
     paddingLeft: 30,
     paddingRight: 20,
     backgroundColor: theme.menuBackground,
   },
   containerContent: {
-    paddingBottom: 20,
+    paddingVertical: 12,
   },
   ltrRow: {
     flexDirection: 'row',

--- a/app/components/ChapterList.js
+++ b/app/components/ChapterList.js
@@ -13,6 +13,7 @@ class ChapterList extends Component {
     return (
       <ScrollView
         style={styles.container}
+        contentContainerStyle={styles.containerContent}
         automaticallyAdjustContentInsets={false}>
         {this.props.chapters.map((chapter, i) => {
           return (
@@ -59,6 +60,9 @@ const styles = StyleSheet.create({
     paddingLeft: 30,
     paddingRight: 20,
     backgroundColor: theme.menuBackground,
+  },
+  containerContent: {
+    paddingBottom: 20,
   },
   ltrRow: {
     flexDirection: 'row',


### PR DESCRIPTION
Without padding, the last chapter selection is cut off

Before:

<img width="394" alt="screen shot 2017-04-24 at 9 40 32 pm" src="https://cloud.githubusercontent.com/assets/224622/25369179/ef6ca3bc-2936-11e7-9b49-71fcd912e7b4.png">
<img width="543" alt="screen shot 2017-04-24 at 9 40 59 pm" src="https://cloud.githubusercontent.com/assets/224622/25369183/f352ab8e-2936-11e7-8e44-02ebef132ac9.png">

After:

<img width="396" alt="screen shot 2017-04-24 at 9 41 23 pm" src="https://cloud.githubusercontent.com/assets/224622/25369187/f9b4af5e-2936-11e7-92ec-168a5d924a61.png">
<img width="548" alt="screen shot 2017-04-24 at 9 41 13 pm" src="https://cloud.githubusercontent.com/assets/224622/25369188/fc3208a8-2936-11e7-80ba-4c235886aaf8.png">
